### PR TITLE
Add HBase::Table#mutate method (#20), etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,17 @@ ret = table.append 'rowkey1', title: ' (limited edition)', summary: ' ...'
 puts ret[:title]   # Updated title
 ```
 
+### Atomic mutations on a single row (PUTs and DELETEs)
+
+```ruby
+# Currently Put and Delete are supported
+# - Refer to mutateRow method of org.apache.hadoop.hbase.client.HTable
+table.mutate(rowkey) do |m|
+  m.put comment3: 'Nice', comment4: 'Great'
+  m.delete :comment1, :comment2
+end
+```
+
 ### SCAN
 
 `HBase::Table` itself is an enumerable object.

--- a/lib/hbase-jruby/dependency.rb
+++ b/lib/hbase-jruby/dependency.rb
@@ -162,6 +162,7 @@ class HBase
           org.apache.hadoop.hbase.client.Delete
           org.apache.hadoop.hbase.client.Increment
           org.apache.hadoop.hbase.client.Put
+          org.apache.hadoop.hbase.client.RowMutations
           org.apache.hadoop.hbase.io.hfile.Compression
           org.apache.hadoop.hbase.regionserver.StoreFile
         ],

--- a/lib/hbase-jruby/row.rb
+++ b/lib/hbase-jruby/row.rb
@@ -269,7 +269,7 @@ class Row
 
 private
   def get_value col, with_versions = false
-    cf, cq, _ = @table.lookup_and_parse col
+    cf, cq, _ = @table.lookup_and_parse col, true
     if with_versions
       # Need to make it a Ruby hash:
       #   Prevents implicit conversion from ruby type to java type when updating the Hash

--- a/lib/hbase-jruby/schema.rb
+++ b/lib/hbase-jruby/schema.rb
@@ -86,9 +86,10 @@ class Schema
 
   # @private
   # @param [Symbol] table
-  def lookup_and_parse table, col
+  def lookup_and_parse table, col, expect_cq
     cf, cq, type = lookup table, col
     cf, cq = Util.parse_column_name(cf ? [cf, cq] : col)
+    raise ArgumentError, "Invalid column key: #{col}" if expect_cq && cq.nil?
     return [cf, cq, type]
   end
 

--- a/lib/hbase-jruby/scoped.rb
+++ b/lib/hbase-jruby/scoped.rb
@@ -615,7 +615,7 @@ private
       case f
       when Hash
         f.map { |col, val|
-          cf, cq, type = @table.lookup_and_parse col
+          cf, cq, type = @table.lookup_and_parse col, true
 
           case val
           when Array

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ unless defined? Enumerator
 end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$rowkey = Time.now.to_i
 
 require "hbase-jruby"
 if dist = ENV['HBASE_JRUBY_TEST_DIST']
@@ -31,7 +32,8 @@ class TestHBaseJRubyBase < Test::Unit::TestCase
   hbase.close
 
   def connect
-    HBase.new 'hbase.zookeeper.quorum' => ZK
+    HBase.new('hbase.zookeeper.quorum' => ZK,
+              'hbase.client.retries.number' => 10) # For region-split test
   end
 
   def setup
@@ -51,6 +53,10 @@ class TestHBaseJRubyBase < Test::Unit::TestCase
       @table.delete(*@table.map { |row| [row.rowkey(:raw)] })
       assert_equal 0, @table.count
     end
+  end
+
+  def next_rowkey
+    $rowkey += 1
   end
 
   def teardown

--- a/test/test_table.rb
+++ b/test/test_table.rb
@@ -34,8 +34,11 @@ class TestTable < TestHBaseJRubyBase
   end
 
   def test_put_then_get
+    row1 = next_rowkey.to_s
+    row2 = next_rowkey.to_s
+    row3 = next_rowkey.to_s
     # Single record put
-    assert_equal 1, @table.put('row1',
+    assert_equal 1, @table.put(row1,
                                'cf1:a'     => 2,
                                'cf1:b'     => 'b',
                                'cf1:c'     => 6.28,
@@ -46,7 +49,7 @@ class TestTable < TestHBaseJRubyBase
                                'cf1:short' => { :short => 200 },
                                'cf1:int'   => { :int   => 300 },
                                'cf1:str1'  => "Goodbye", 'cf1:str2' => "Cruel world")
-    assert_equal 1, @table.put('row1',
+    assert_equal 1, @table.put(row1,
                                'cf1:a'     => 1,
                                'cf1:b'     => 'a',
                                'cf1:c'     => 3.14,
@@ -60,66 +63,66 @@ class TestTable < TestHBaseJRubyBase
                                'cf1:str1'  => "Hello", 'cf1:str2' => "World")
     # Batch put
     assert_equal 2, @table.put(
-      'row2' => { 'cf1:a' => 2, 'cf1:b' => 'b', 'cf1:c' => 6.28 },
-      'row3' => { 'cf1:a' => 4, 'cf1:b' => 'c', 'cf1:c' => 6.28 })
+      row2 => { 'cf1:a' => 2, 'cf1:b' => 'b', 'cf1:c' => 6.28 },
+      row3 => { 'cf1:a' => 4, 'cf1:b' => 'c', 'cf1:c' => 6.28 })
 
     # single-get (latest version)
-    result = @table.get('row1')
+    result = @table.get(row1)
     # Test enumerator
     assert_equal result.to_a, result.each.each.to_a
     assert_equal result.to_a, result.each.take_while { true }.to_a
 
-    assert_equal 'row1', @table.get('row1').rowkey(:string)
-    assert_equal 'row1', @table.get('row1').rowkey(:string)
-    assert_equal 1,      @table.get('row1').fixnum('cf1:a')
-    assert_equal 'a',    @table.get('row1').string('cf1:b')
-    assert_equal 'a',    String.from_java_bytes(@table.get('row1').raw('cf1:b'))
-    assert_equal 3.14,   @table.get('row1').float('cf1:c')
-    assert_equal true,   @table.get('row1').boolean('cf1:d')
-    assert_equal :sym,   @table.get('row1').symbol('cf1:f')
-    assert_equal BigDecimal.new("123.456"), @table.get('row1').bigdecimal('cf1:g')
-    assert_equal 101,   @table.get('row1').byte('cf1:byte')
-    assert_equal 201,   @table.get('row1').short('cf1:short')
-    assert_equal 301,   @table.get('row1').int('cf1:int')
+    assert_equal row1, @table.get(row1).rowkey(:string)
+    assert_equal row1, @table.get(row1).rowkey(:string)
+    assert_equal 1,      @table.get(row1).fixnum('cf1:a')
+    assert_equal 'a',    @table.get(row1).string('cf1:b')
+    assert_equal 'a',    String.from_java_bytes(@table.get(row1).raw('cf1:b'))
+    assert_equal 3.14,   @table.get(row1).float('cf1:c')
+    assert_equal true,   @table.get(row1).boolean('cf1:d')
+    assert_equal :sym,   @table.get(row1).symbol('cf1:f')
+    assert_equal BigDecimal.new("123.456"), @table.get(row1).bigdecimal('cf1:g')
+    assert_equal 101,   @table.get(row1).byte('cf1:byte')
+    assert_equal 201,   @table.get(row1).short('cf1:short')
+    assert_equal 301,   @table.get(row1).int('cf1:int')
 
     # single-get-multi-col (deprecated since 0.3)
-    # assert_equal %w[Hello World], @table.get('row1').string(['cf1:str1', 'cf1:str2'])
-    # assert_equal [301, 401], @table.get('row1').int(['cf1:int', 'cf1:int2'])
+    # assert_equal %w[Hello World], @table.get(row1).string(['cf1:str1', 'cf1:str2'])
+    # assert_equal [301, 401], @table.get(row1).int(['cf1:int', 'cf1:int2'])
 
     # single-get-multi-ver
-    assert_equal [1, 2],        @table.get('row1').fixnums('cf1:a').values
-    assert_equal %w[a b],       @table.get('row1').strings('cf1:b').values
-    assert_equal %w[a b],       @table.get('row1').raws('cf1:b').values.map { |v| String.from_java_bytes v }
-    assert_equal [3.14, 6.28],  @table.get('row1').floats('cf1:c').values
-    assert_equal [true, false], @table.get('row1').booleans('cf1:d').values
-    assert_equal [:sym, :bol],  @table.get('row1').symbols('cf1:f').values
+    assert_equal [1, 2],        @table.get(row1).fixnums('cf1:a').values
+    assert_equal %w[a b],       @table.get(row1).strings('cf1:b').values
+    assert_equal %w[a b],       @table.get(row1).raws('cf1:b').values.map { |v| String.from_java_bytes v }
+    assert_equal [3.14, 6.28],  @table.get(row1).floats('cf1:c').values
+    assert_equal [true, false], @table.get(row1).booleans('cf1:d').values
+    assert_equal [:sym, :bol],  @table.get(row1).symbols('cf1:f').values
     assert_equal [
       BigDecimal.new("123.456"),
-      BigDecimal.new("456.123")], @table.get('row1').bigdecimals('cf1:g').values
-    assert_equal [101, 100], @table.get('row1').bytes('cf1:byte').values
-    assert_equal [201, 200], @table.get('row1').shorts('cf1:short').values
-    assert_equal [301, 300], @table.get('row1').ints('cf1:int').values
+      BigDecimal.new("456.123")], @table.get(row1).bigdecimals('cf1:g').values
+    assert_equal [101, 100], @table.get(row1).bytes('cf1:byte').values
+    assert_equal [201, 200], @table.get(row1).shorts('cf1:short').values
+    assert_equal [301, 300], @table.get(row1).ints('cf1:int').values
 
-    assert @table.get('row1').fixnums('cf1:a').keys.all? { |k| k.instance_of? Fixnum }
+    assert @table.get(row1).fixnums('cf1:a').keys.all? { |k| k.instance_of? Fixnum }
 
     # single-get-multi-col-multi=ver (deprecated since 0.3)
-    # rets = @table.get('row1').strings(['cf1:str1', 'cf1:str2'])
+    # rets = @table.get(row1).strings(['cf1:str1', 'cf1:str2'])
     # assert_equal ['Hello', 'World'], rets.map(&:values).map(&:first)
     # assert_equal ['Goodbye', 'Cruel world'], rets.map(&:values).map(&:last)
 
     # multi-get
-    assert_equal %w[row1 row2 row3], @table.get(['row1', 'row2', 'row3']).map { |r| r.rowkey :string }
-    assert_equal [1, 2, 4         ], @table.get(['row1', 'row2', 'row3']).map { |r| r.fixnum('cf1:a') }
-    assert_equal [3.14, 6.28, 6.28], @table.get(['row1', 'row2', 'row3']).map { |r| r.float('cf1:c') }
+    assert_equal [row1, row2, row3], @table.get([row1, row2, row3]).map { |r| r.rowkey :string }
+    assert_equal [1, 2, 4         ], @table.get([row1, row2, row3]).map { |r| r.fixnum('cf1:a') }
+    assert_equal [3.14, 6.28, 6.28], @table.get([row1, row2, row3]).map { |r| r.float('cf1:c') }
     assert_equal [nil, nil        ], @table.get(['xxx', 'yyy'])
 
     # Unavailable columns
-    assert_equal nil, @table.get('row1').symbol('cf1:xxx')
-    assert_equal nil, @table.get('row1').fixnum('cf1:xxx')
+    assert_equal nil, @table.get(row1).symbol('cf1:xxx')
+    assert_equal nil, @table.get(row1).fixnum('cf1:xxx')
 
     # Unavailable columns (plural form)
-    assert_equal({}, @table.get('row1').strings('cf1:xxx'))
-    assert_equal({}, @table.get('row1').strings('cfx:xxx'))
+    assert_equal({}, @table.get(row1).strings('cf1:xxx'))
+    assert_equal({}, @table.get(row1).strings('cfx:xxx'))
 
     # Row not found
     assert_equal nil, @table.get('xxx')
@@ -128,19 +131,20 @@ class TestTable < TestHBaseJRubyBase
   # Put added after a delete is overshadowed if its timestamp is older than than that of the tombstone
   # https://issues.apache.org/jira/browse/HBASE-2847
   def test_put_delete_put
+    rowkey = next_rowkey
     pend("https://issues.apache.org/jira/browse/HBASE-2847") do
       data = { 'cf1:pdp' => { 1250000000000 => 'A1' } }
-      @table.put :rowkey => data
-      assert_equal 'A1', @table.get(:rowkey).string('cf1:pdp')
-      @table.delete :rowkey
-      assert_nil @table.get(:rowkey)
-      @table.put :rowkey => data
-      assert_equal 'A1', @table.get(:rowkey).string('cf1:pdp')
+      @table.put rowkey => data
+      assert_equal 'A1', @table.get(rowkey).string('cf1:pdp')
+      @table.delete rowkey
+      assert_nil @table.get(rowkey)
+      @table.put rowkey => data
+      assert_equal 'A1', @table.get(rowkey).string('cf1:pdp')
     end
   end
 
   def test_put_timestamp
-    rowkey = :test_put_timestamp
+    rowkey = next_rowkey
     @table.put rowkey => {
       'cf1:b' => 'B1',
       'cf1:a' => {
@@ -157,113 +161,125 @@ class TestTable < TestHBaseJRubyBase
   end
 
   def test_increment
-    @table.put('row1', 'cf1:counter' => 1, 'cf1:counter2' => 100)
-    assert_equal 1, @table.get('row1').fixnum('cf1:counter')
+    row1 = next_rowkey.to_s
+    row2 = next_rowkey.to_s
 
-    ret = @table.increment('row1', 'cf1:counter', 1)
+    @table.put(row1, 'cf1:counter' => 1, 'cf1:counter2' => 100)
+    assert_equal 1, @table.get(row1).fixnum('cf1:counter')
+
+    ret = @table.increment(row1, 'cf1:counter', 1)
     assert_equal 2, ret['cf1:counter']
-    assert_equal 2, @table.get('row1').fixnum('cf1:counter')
+    assert_equal 2, @table.get(row1).fixnum('cf1:counter')
 
-    ret = @table.increment('row1', 'cf1:counter', 2)
+    ret = @table.increment(row1, 'cf1:counter', 2)
     assert_equal 4, ret['cf1:counter']
-    assert_equal 4, @table.get('row1').fixnum('cf1:counter')
+    assert_equal 4, @table.get(row1).fixnum('cf1:counter')
 
     # Multi-column increment
-    ret = @table.increment('row1', 'cf1:counter' => 4, 'cf1:counter2' => 100)
+    ret = @table.increment(row1, 'cf1:counter' => 4, 'cf1:counter2' => 100)
     assert_equal 8,   ret['cf1:counter']
-    assert_equal 8,   @table.get('row1').fixnum('cf1:counter')
+    assert_equal 8,   @table.get(row1).fixnum('cf1:counter')
     assert_equal 200, ret['cf1:counter2']
     assert_equal 200, ret[%w[cf1 counter2]]
-    assert_equal 200, @table.get('row1').fixnum('cf1:counter2')
+    assert_equal 200, @table.get(row1).fixnum('cf1:counter2')
 
     # Multi-row multi-column increment
-    @table.put('row2', 'cf1:counter' => 1, 'cf1:counter2' => 100)
-    ret = @table.increment 'row1' => { 'cf1:counter' => 4, 'cf1:counter2' => 100 },
-                           'row2' => { 'cf1:counter' => 1, 'cf1:counter2' => 100 }
-    assert_equal 12,  ret['row1']['cf1:counter']
-    assert_equal 300, ret['row1']['cf1:counter2']
-    assert_equal 2,   ret['row2']['cf1:counter']
-    assert_equal 200, ret['row2']['cf1:counter2']
-    assert_equal 200, ret['row2'][%w[cf1 counter2]]
-    assert_equal 12,  @table.get('row1').fixnum('cf1:counter')
-    assert_equal 300, @table.get('row1').fixnum('cf1:counter2')
-    assert_equal 2,   @table.get('row2').fixnum('cf1:counter')
-    assert_equal 200, @table.get('row2').fixnum('cf1:counter2')
+    @table.put(row2, 'cf1:counter' => 1, 'cf1:counter2' => 100)
+    ret = @table.increment row1 => { 'cf1:counter' => 4, 'cf1:counter2' => 100 },
+                           row2 => { 'cf1:counter' => 1, 'cf1:counter2' => 100 }
+    assert_equal 12,  ret[row1]['cf1:counter']
+    assert_equal 300, ret[row1]['cf1:counter2']
+    assert_equal 2,   ret[row2]['cf1:counter']
+    assert_equal 200, ret[row2]['cf1:counter2']
+    assert_equal 200, ret[row2][%w[cf1 counter2]]
+    assert_equal 12,  @table.get(row1).fixnum('cf1:counter')
+    assert_equal 300, @table.get(row1).fixnum('cf1:counter2')
+    assert_equal 2,   @table.get(row2).fixnum('cf1:counter')
+    assert_equal 200, @table.get(row2).fixnum('cf1:counter2')
   end
 
   def test_delete
-    @table.put('row1', 'cf1' => 0, 'cf1:a' => 1, 'cf1:b' => 2, 'cf2:c' => 3, 'cf2:d' => 4)
+    row1 = next_rowkey.to_s
+    row2 = next_rowkey.to_s
+    row3 = next_rowkey.to_s
+
+    @table.put(row1, 'cf1:' => 0, 'cf1:a' => 1, 'cf1:b' => 2, 'cf2:c' => 3, 'cf2:d' => 4)
     sleep 0.1
-    @table.put('row1', 'cf2:d' => 5)
+    @table.put(row1, 'cf2:d' => 5)
     sleep 0.1
-    @table.put('row1', 'cf2:d' => 6)
-    versions = @table.get('row1').to_H[%w[cf2 d]].keys
+    @table.put(row1, 'cf2:d' => 6)
+    versions = @table.get(row1).to_H[%w[cf2 d]].keys
     assert versions[0] > versions[1]
     assert versions[1] > versions[2]
 
     # Deletes a version (Fixnum and Time as timestamps)
-    @table.delete('row1', 'cf2:d', versions[0], Time.at(versions[2] / 1000.0))
-    new_versions = @table.get('row1').to_H[%w[cf2 d]].keys
+    @table.delete(row1, 'cf2:d', versions[0], Time.at(versions[2] / 1000.0))
+    new_versions = @table.get(row1).to_H[%w[cf2 d]].keys
     assert_equal new_versions, [versions[1]]
 
     # Deletes a column
-    assert_equal 3, @table.get('row1').fixnum('cf2:c')
-    @table.delete('row1', 'cf2:c')
-    assert_nil @table.get('row1').to_h['cf2:c']
+    assert_equal 3, @table.get(row1).fixnum('cf2:c')
+    @table.delete(row1, 'cf2:c')
+    assert_nil @table.get(row1).to_h['cf2:c']
 
     # Deletes a column with empty qualifier
-    assert_equal 0, @table.get('row1').fixnum('cf1')
-    @table.delete('row1', 'cf1:')
-    assert_equal 1, @table.get('row1').fixnum('cf1:a')
-    assert_equal 2, @table.get('row1').fixnum('cf1:b')
-    assert_nil @table.get('row1').to_h['cf1']
-    assert_nil @table.get('row1').to_h['cf1:']
+    assert_equal 0, @table.get(row1).fixnum('cf1:')
+    @table.delete(row1, 'cf1:')
+    assert_equal 1, @table.get(row1).fixnum('cf1:a')
+    assert_equal 2, @table.get(row1).fixnum('cf1:b')
+    assert_nil @table.get(row1).to_h['cf1:']
 
     # Deletes a column family
-    assert_equal 1, @table.get('row1').fixnum('cf1:a')
-    assert_equal 2, @table.get('row1').fixnum('cf1:b')
-    @table.delete('row1', 'cf1') # No trailing colon
-    assert_nil @table.get('row1').to_h['cf1:a']
-    assert_nil @table.get('row1').to_h['cf1:b']
+    assert_equal 1, @table.get(row1).fixnum('cf1:a')
+    assert_equal 2, @table.get(row1).fixnum('cf1:b')
+    @table.delete(row1, 'cf1') # No trailing colon
+    assert_nil @table.get(row1).to_h['cf1:a']
+    assert_nil @table.get(row1).to_h['cf1:b']
 
     # Deletes a row
-    @table.delete('row1')
-    assert_nil @table.get('row1')
+    @table.delete(row1)
+    assert_nil @table.get(row1)
 
     # Batch delete
-    @table.put('row2', 'cf1:a' => 1)
-    @table.put('row3', 'cf1:a' => 1, 'cf1:b' => 2)
+    @table.put(row2, 'cf1:a' => 1)
+    @table.put(row3, 'cf1:a' => 1, 'cf1:b' => 2)
 
-    @table.delete ['row2'], ['row3', 'cf1:a']
-    assert_nil @table.get('row2')
-    assert_nil @table.get('row3').to_h['cf1:a']
-    assert_equal 2, @table.get('row3').fixnum('cf1:b')
+    @table.delete [row2], [row3, 'cf1:a']
+    assert_nil @table.get(row2)
+    assert_nil @table.get(row3).to_h['cf1:a']
+    assert_equal 2, @table.get(row3).fixnum('cf1:b')
   end
 
   def test_delete_advanced
-    @table.put('row1', 'cf1' => 0, 'cf1:a' => 1, 'cf1:b' => 2, 'cf2:c' => 3, 'cf2:d' => 4)
-    @table.delete('row1', 'cf1:', 'cf1:b', 'cf2')
-    assert_equal 1, @table.get('row1').to_h.keys.length
-    assert_equal 1, @table.get('row1').fixnum('cf1:a')
+    row1 = next_rowkey.to_s
+    drow = next_rowkey.to_s
+
+    @table.put(row1, 'cf1:' => 0, 'cf1:a' => 1, 'cf1:b' => 2, 'cf2:c' => 3, 'cf2:d' => 4)
+    @table.delete(row1, 'cf1:', 'cf1:b', 'cf2')
+    assert_equal 1, @table.get(row1).to_h.keys.length
+    assert_equal 1, @table.get(row1).fixnum('cf1:a')
 
     ts = Time.now
-    @table.put('drow2', 'cf1:a' => { 1000 => 1, 2000 => 2, 3000 => 3 },
+    @table.put(drow, 'cf1:a' => { 1000 => 1, 2000 => 2, 3000 => 3 },
                         'cf1:b' => { 4000 => 4, 5000 => 5, 6000 => 6 },
                         'cf2:c' => 3, 'cf2:d' => 4, 'cf3:e' => 5)
-    @table.delete('drow2', 'cf1:a', 1000, Time.at(2),
+    @table.delete(drow, 'cf1:a', 1000, Time.at(2),
                            'cf2:c',
                            'cf1:b', 5000,
                            'cf3')
 
-    assert_equal 3, @table.get('drow2').to_h.keys.length
+    assert_equal 3, @table.get(drow).to_h.keys.length
 
-    assert_equal 1, @table.get('drow2').to_H['cf1:a'].length
-    assert_equal 2, @table.get('drow2').to_H['cf1:b'].length
-    assert_equal 3000, @table.get('drow2').to_H['cf1:a'].keys.first
-    assert_equal [6000, 4000], @table.get('drow2').to_H['cf1:b'].keys
+    assert_equal 1, @table.get(drow).to_H['cf1:a'].length
+    assert_equal 2, @table.get(drow).to_H['cf1:b'].length
+    assert_equal 3000, @table.get(drow).to_H['cf1:a'].keys.first
+    assert_equal [6000, 4000], @table.get(drow).to_H['cf1:b'].keys
   end
 
   def test_delete_advanced_with_schema
+    row1 = next_rowkey.to_s
+    drow = next_rowkey.to_s
+
     @hbase.schema[@table.name] = {
       :cf1 => {
         :a => :int,
@@ -277,29 +293,29 @@ class TestTable < TestHBaseJRubyBase
         :e => :fixnum
       }
     }
-    @table.put('row1', 'cf1' => 0, :a => 1, :b => 2, :c => 3, :d => 4)
-    @table.delete('row1', 'cf1:', :b, 'cf2')
-    assert_equal 1, @table.get('row1').to_h.keys.length
-    assert_equal 1, @table.get('row1').to_h[:a]
-    assert_equal 1, @table.get('row1').int(:a)
+    @table.put(row1, 'cf1:' => 0, :a => 1, :b => 2, :c => 3, :d => 4)
+    @table.delete(row1, 'cf1:', :b, 'cf2')
+    assert_equal 1, @table.get(row1).to_h.keys.length
+    assert_equal 1, @table.get(row1).to_h[:a]
+    assert_equal 1, @table.get(row1).int(:a)
 
     ts = Time.now
-    @table.put('drow3', :a => { 1000 => 1, 2000 => 2, 3000 => 3 },
+    @table.put(drow, :a => { 1000 => 1, 2000 => 2, 3000 => 3 },
                         :b => { 4000 => 4, 5000 => 5, 6000 => 6 },
                         :c => 3,
                         :d => 4,
                         :e => 5)
-    @table.delete('drow3', :a, 1000, Time.at(2),
+    @table.delete(drow, :a, 1000, Time.at(2),
                            :c,
                            [:cf1, :b], 5000,
                            'cf3')
 
-    assert_equal 3, @table.get('drow3').to_h.keys.length
+    assert_equal 3, @table.get(drow).to_h.keys.length
 
-    assert_equal 1, @table.get('drow3').to_H[:a].length
-    assert_equal 2, @table.get('drow3').to_H[:b].length
-    assert_equal 3000, @table.get('drow3').to_H[:a].keys.first
-    assert_equal [6000, 4000], @table.get('drow3').to_H[:b].keys
+    assert_equal 1, @table.get(drow).to_H[:a].length
+    assert_equal 2, @table.get(drow).to_H[:b].length
+    assert_equal 3000, @table.get(drow).to_H[:a].keys.first
+    assert_equal [6000, 4000], @table.get(drow).to_H[:b].keys
   end
 
   def test_delete_row
@@ -334,15 +350,14 @@ class TestTable < TestHBaseJRubyBase
 
     [
       # Without schema
-      [1, 'cf1:a', 'cf1:b', 'cf1:c'],
-      [2, 'cf1:a', 'cf1:b', 'cf1:c'],
+      [next_rowkey, 'cf1:a', 'cf1:b', 'cf1:c'],
+      [next_rowkey, 'cf1:a', 'cf1:b', 'cf1:c'],
       # With schema
-      [1, :a, :b, :c],
-      [2, :a, :b, :c],
+      [next_rowkey, :a, :b, :c],
+      [next_rowkey, :a, :b, :c],
     ].each do |args|
       rk, a, b, c = args
 
-      @table.delete_row rk
       @table.put rk, 'cf1:a' => 100
 
       # not nil
@@ -376,7 +391,7 @@ class TestTable < TestHBaseJRubyBase
     ].each do |abcd|
       a, b, c, d = abcd
 
-      rk = (Time.now.to_f * 1000).to_i
+      rk = next_rowkey
       ts = Time.now
       @table.put rk, a => 100, b => 200,
         c => { ts => 300, (ts - 1000) => 400, (ts - 2000).to_i => 500 },
@@ -407,12 +422,45 @@ class TestTable < TestHBaseJRubyBase
   end
 
   def test_append
-    @table.put 1000, 'cf1:a' => 'hello', 'cf2:b' => 'foo'
-    result = @table.append 1000, 'cf1:a' => ' world', 'cf2:b' => 'bar'
+    rk = next_rowkey
+    @table.put rk, 'cf1:a' => 'hello', 'cf2:b' => 'foo'
+    result = @table.append rk, 'cf1:a' => ' world', 'cf2:b' => 'bar'
     assert_equal 'hello world', result['cf1:a'].to_s
     assert_equal 'foobar',      result[%w[cf2 b]].to_s
-    assert_equal 'hello world', @table.get(1000).string('cf1:a')
-    assert_equal 'foobar',      @table.get(1000).string('cf2:b')
+    assert_equal 'hello world', @table.get(rk).string('cf1:a')
+    assert_equal 'foobar',      @table.get(rk).string('cf2:b')
+  end
+
+  def test_mutate
+    rk = next_rowkey
+    @table.put rk,
+      'cf1:a' => 100, 'cf1:b' => 'hello', 'cf1:c' => 'hola',
+      'cf2:d' => 3.14
+    ret = @table.mutate(rk) { |m|
+      m.put 'cf1:a' => 200
+      m.delete 'cf1:c', 'cf2'
+      m.put 'cf1:z' => true
+    }
+    assert_equal nil, ret
+
+    row = @table.get(rk)
+    assert_equal 200,     row.long('cf1:a')
+    assert_equal 'hello', row.string('cf1:b')
+    assert_equal nil,     row.string('cf1:c')
+    assert_equal nil,     row['cf1:c']
+    assert_equal true,    row.boolean('cf1:z')
+    assert_equal nil,     row.float('cf2:d')
+    assert_equal nil,     row['cf2:d']
+
+    @table.mutate(rk) { |m| } # Nothing
+    @table.mutate(rk) { |m| m.delete }
+    assert_equal nil, @table.get(rk)
+  end
+
+  def test_invalid_column_key
+    assert_raise(ArgumentError) {
+      @table.put next_rowkey, :some_column => 1
+    }
   end
 end
 


### PR DESCRIPTION
- Implement mutate method for atomic mutations on a single row
- Disallow specifying empty qualifier as 'cf'. Should be written as 'cf:'
- Throw ArgumentError when invalid column key is given
