### PR TITLE
Fix documentation table.create arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ hbase = HBase.new 'localhost'
 # Table object
 table = hbase[:test_table]
 table.drop! if table.exists?
-table.create! :cf1, :cf2
+table.create! :cf1 => {}, :cf2 => {}
 
 # PUT
 table.put 'rowkey1' => { 'cf1:a' => 100, 'cf2:b' => 'Hello' },


### PR DESCRIPTION
When running example, got:

TypeError: can't convert Symbol into Integer
       [] at org/jruby/RubyString.java:3722
       [] at org/jruby/RubySymbol.java:416
  create! at /opt/logstash/vendor/jruby/lib/ruby/gems/shared/gems/hbase-jruby-0.7.0-java/lib/hbase-jruby/table/admin.rb:61

Error.

This commit fix it.